### PR TITLE
Add support for rejected responses

### DIFF
--- a/dalle-node.js
+++ b/dalle-node.js
@@ -42,12 +42,13 @@ export class Dalle {
                     (error, response, body) => {
                       if (error) {
                         console.log(error);
-                      } else {
-                        if (body.status === "succeeded") {
-                          const generations = body.generations;
-                          clearInterval(refreshIntervalId);
-                          resolve(generations.data);
-                        }
+                      } else if (body.status === "rejected") {
+                        clearInterval(refreshIntervalId);
+                        resolve(body.status_information);
+                      } else if (body.status === "succeeded") {
+                        const generations = body.generations;
+                        clearInterval(refreshIntervalId);
+                        resolve(generations.data);
                       }
                     }
                   );


### PR DESCRIPTION
Currently rejected responses will hang as the promise never resolves. This PR adds support for rejected responses. There may be other statuses that should be handled also but currently only accounting for succeeded and rejected.