### PR TITLE
:sparkles: Add getCredits() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,28 @@ const task = await dalle.getTask("task-nERkiKsdjVCSZ50yD69qewID");
 
 Returns a task object.
 
+### `getCredits()`
+
+```javascript
+const creditsSummary = await dalle.getCredits();
+const totalCreditsLeft = creditsSummary.aggregate_credits;
+```
+
+Returns an object with the following properties.
+
+```json
+{
+  "aggregate_credits": 180,
+  "next_grant_ts": 123456789,
+  "breakdown": {
+    "free": 0,
+    "grant_beta_tester": 65,
+    "paid_dalle_15_115": 115
+  },
+  "object": "credit_summary"
+}
+```
+
 # Examples
 
 [Nextjs Application](https://github.com/1998code/DALLE-2-App)

--- a/dalle-node.js
+++ b/dalle-node.js
@@ -3,11 +3,11 @@ import got from 'got';
 export class Dalle {
   constructor(bearerToken) {
     this.bearerToken = bearerToken;
-    this.url = "https://labs.openai.com/api/labs/tasks";
+    this.url = "https://labs.openai.com/api/labs";
   }
 
   async generate(prompt) {
-    let task = await got.post(this.url, {
+    let task = await got.post(`${this.url}/tasks`, {
       json: {
         task_type: "text2im",
         prompt: {
@@ -38,7 +38,7 @@ export class Dalle {
   }
 
   async getTask(taskId) {
-    return await got.get(`${ this.url }/${ taskId }`, {
+    return await got.get(`${this.url}/tasks/${ taskId }`, {
       headers: {
         Authorization: "Bearer " + this.bearerToken,
       },
@@ -46,7 +46,15 @@ export class Dalle {
   }
   
   async list(options = { limit: 50, fromTs: 0 }) {
-    return await got.get(`${ this.url }?limit=${ options.limit }${ options.fromTs ? `&from_ts=${ options.fromTs }` : '' }`, {
+    return await got.get(`${this.url}/tasks?limit=${ options.limit }${ options.fromTs ? `&from_ts=${ options.fromTs }` : '' }`, {
+        headers: {
+          Authorization: "Bearer " + this.bearerToken,
+        },
+      }).json();
+  }
+  
+  async getCredits() {
+    return await got.get(`${ this.url }/billing/credit_summary`, {
         headers: {
           Authorization: "Bearer " + this.bearerToken,
         },


### PR DESCRIPTION
Added a function to get the credits available. Remembered to update the README docs this time. Slightly adjusted `this.url` since this function does not use /tasks, it uses /billing instead.

The call looks like:
```js
const creditsSummary = await dalle.getCredits();
```

Returned object looks like:
```json
{
  "aggregate_credits": 180,
  "next_grant_ts": 123456789,
  "breakdown": {
    "free": 0,
    "grant_beta_tester": 65,
    "paid_dalle_15_115": 115
  },
  "object": "credit_summary"
}
```

In most cases, just the total credits left would be wanted:
```js
const totalCreditsLeft = (await dalle.getCredits()).aggregate_credits;
```

To get the date + time that the free credits will refresh:
```js
const credits = await dalle.getCredits()
console.log('Free credits refresh on:', new Date(credits.next_grant_ts * 1000).toLocaleString());
```